### PR TITLE
Adds turbolinks library to avoid full-page reloads

### DIFF
--- a/common/layout.html
+++ b/common/layout.html
@@ -22,15 +22,16 @@
 	<body class="{{body_class}}">
 		<div id="container">
 			<h1 class="logo"><a title="Raspberry Pi GPIO Pinout home" href="/"><img src="{{resource_url}}pinout-logo.png" />Raspberry Pi Pinout</a></h1>
-			
+
 			{{main_content}}
-			
+
 			<div class="footer">
 			{{footer}}
 			</div>
 		</div>
 
 		<script type="text/javascript" src="//cdn.jsdelivr.net/jquery/1.9.1/jquery-1.9.1.min.js"></script>
+		<script type="text/javascript" src="//cdn.jsdelivr.net/turbolinks/5.0.0/turbolinks.js"></script>
 		<script type="text/javascript" src="//cdn.jsdelivr.net/prettify/0.1/prettify.js"></script>
     	<script src='{{resource_url}}prettify/lang-bash.js'></script>
 		<script src='{{resource_url}}pinout.js?v={{v}}'></script>


### PR DESCRIPTION
I use `pinout.xyz`all the time and slight delay when you click on a link and the page reloads is slightly annoying.

This PR adds the [Turbolinks](https://github.com/turbolinks/turbolinks) library to fetch the next page using Ajax when a link is clicked. This results in a noticeable speed improvement when navigating around.

The URL is still updated as you navigate around so there's no change to the user, apart from the speed improvements.

On unsupported browsers, the library will gracefully degrade back to full-page reloads without JavaScript.