### PR TITLE
update buy link for Pi-LITEr

### DIFF
--- a/src/en/overlay/pi-liter.md
+++ b/src/en/overlay/pi-liter.md
@@ -7,7 +7,7 @@ formfactor: Custom
 manufacturer: Ciseco
 description: An 8 LED strip for the Raspberry Pi
 url: http://gpiozero.readthedocs.io/en/v1.3.1/api_boards.html#piliter
-buy: http://cpc.farnell.com/wirelessthings/pi-liter/pi-lite-junior-led-io-board-for/dp/SC13293
+buy: http://store.acmeun.com/products/pi-liter-8-led-strip-for-the-raspberry-pi.html
 image: 'pi-liter.png'
 pincount: 26
 eeprom: no


### PR DESCRIPTION
The "buy" link for Pi-LITEr is a dead link.  I bought my Pi-LITEr from Acme Unlimited, so I thought I'd change the "buy" link to point there, instead.