### PR TITLE
PaPiRus HAT and Zero

### DIFF
--- a/src/en/overlay/papirus-hat.md
+++ b/src/en/overlay/papirus-hat.md
@@ -72,7 +72,7 @@ pin:
     mode: input
     active: low
 i2c:
-  '0x4B':
+  '0x48':
     name: Temperature Sensor
     device: LM75BD
   '0x6F':
@@ -98,7 +98,5 @@ Unlike conventional displays, ePaper reflects light, and is capable of holding t
 To get the HAT set up and ready to go you can use the one-line product installer:
 
 ```bash
-curl -sSL https://goo.gl/i1Imel | sudo bash
+curl -sSL https://pisupp.ly/papiruscode | sudo bash
 ```
-
-Before using PaPiRus, do not forget to enable the SPI and I2C interfaces!

--- a/src/en/overlay/papirus-zero.md
+++ b/src/en/overlay/papirus-zero.md
@@ -72,7 +72,7 @@ pin:
     mode: input
     active: low
 i2c:
-  '0x4B':
+  '0x48':
     name: Temperature Sensor
     device: LM75BD
 -->
@@ -91,7 +91,5 @@ Unlike conventional displays, ePaper reflects light, and is capable of holding t
 To get the pHAT set up and ready to go you can use the one-line product installer:
 
 ```bash
-curl -sSL https://goo.gl/i1Imel | sudo bash
+curl -sSL https://pisupp.ly/papiruscode | sudo bash
 ```
-
-Before using PaPiRus, do not forget to enable the SPI and I2C interfaces!


### PR DESCRIPTION
Changed the I2C address for the LM75BM to 0x48.
Changed the install URL and removed recommendations to enable I2C and SPI as it is now done automatically.