### PR TITLE
SPI does not (usually) do daisy-chaining

### DIFF
--- a/src/en/overlay/spi.md
+++ b/src/en/overlay/spi.md
@@ -50,7 +50,7 @@ pin:
 ###SPI0 pins in BCM mode are: 9, 10, 11 + 7/8
 ###SPI0 pins in WiringPi are: 12, 13, 14 + 10/11
 ---
-Known as the four-wire serial bus, SPI lets you daisy-chain multiple compatible devices off a single set of pins by assigning them different chip-select pins.
+Known as the four-wire serial bus, SPI lets you attach multiple compatible devices to a single set of pins by assigning them different chip-select pins.
 
 A useful example of an SPI peripheral is the MCP23S17 digital IO expander chip ( Note the S in place of the 0 found on the I2C version ). You can also use the SPI port to "Bit-Bang" an ATmega 328, loading Arduino sketches onto it with Gordon Hendersons' modified version of AVRDude.
 


### PR DESCRIPTION
While some devices might support daisy-chaining, in general, SPI devices don't, and it's not the way SPI is usually used.

Also, using multiple CS lines isn't what allows it. For daisy chaining you usually only use a single CS line for all devices.