### PR TITLE
Add Enviro+ BMC14 pinout information. Closes #330

### DIFF
--- a/src/en/overlay/pimoroni-enviro-plus.md
+++ b/src/en/overlay/pimoroni-enviro-plus.md
@@ -24,6 +24,9 @@ ground:
   '34':
   '39':
 pin:
+  '8':
+    mode: uart
+    name: PMS5003
   '10':
     mode: uart
     name: PMS5003


### PR DESCRIPTION
pin: 8
mode: uart
name: PMS5003

Thanks!