### PR TITLE
Fix layout of boards rows. Closes #317

### DIFF
--- a/resources/pinout.scss
+++ b/resources/pinout.scss
@@ -169,11 +169,24 @@ Content Area
 Boards Page
 */
 
+#boards > ul {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    -webkit-box-align: start;
+    -ms-flex-align: start;
+    align-items: flex-start;
+    -webkit-box-pack: start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+}
+
 #boards .board, #featured .board  {
     box-sizing:border-box;
     width:25%;
     display:block;
-    float:left;
     text-align:center;
 
     a {

--- a/resources/pinout.scss.css
+++ b/resources/pinout.scss.css
@@ -134,11 +134,23 @@ Content Area
 /*
 Boards Page
 */
+#boards > ul {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start; }
+
 #boards .board, #featured .board {
   box-sizing: border-box;
   width: 25%;
   display: block;
-  float: left;
   text-align: center; }
   #boards .board a, #featured .board a {
     padding-top: 20px;


### PR DESCRIPTION
This removes empty spaces from the layout of the boards on the most of
the browsers. The code preserves left aligned layout and is backward
compatible with EI1

Thanks!

![boards-layout](https://user-images.githubusercontent.com/14539/65821077-22679780-e231-11e9-8500-1a8005d27f47.gif)
