### PR TITLE
Add pin 21 (BCM 9) to Inky pHAT requirements

### DIFF
--- a/src/en/overlay/inkyphat.md
+++ b/src/en/overlay/inkyphat.md
@@ -38,6 +38,8 @@ pin:
     active: high
   '19':
     mode: spi
+  '21':
+    mode: spi
   '23':
     mode: spi
   '24':


### PR DESCRIPTION
Physical pin 21 (BCM 9) is used by the Inky pHAT for SPI. However, this pin is not currently listed as used at https://pinout.xyz/pinout/inky_phat.