### PR TITLE
Fix typo in TV Hat manufacturer (Raspberry Pi)

### DIFF
--- a/src/de/translate/tv-hat.md
+++ b/src/de/translate/tv-hat.md
@@ -4,7 +4,7 @@ name: TV HAT
 class: board
 type: other
 formfactor: pHAT
-manufacturer: Rasbperry Pi
+manufacturer: Raspberry Pi
 description: Receives digital DVB-T2 TV streams on your Raspberry Pi to view them or stream them over a network to other devices.
 url: https://www.raspberrypi.org/products/raspberry-pi-tv-hat/
 github:

--- a/src/en/overlay/tv-hat.md
+++ b/src/en/overlay/tv-hat.md
@@ -4,7 +4,7 @@ name: TV HAT
 class: board
 type: other
 formfactor: pHAT
-manufacturer: Rasbperry Pi
+manufacturer: Raspberry Pi
 description: Receives digital DVB-T2 TV streams on your Raspberry Pi to view them or stream them over a network to other devices.
 url: https://www.raspberrypi.org/products/raspberry-pi-tv-hat/
 github:

--- a/src/es/translate/tv-hat.md
+++ b/src/es/translate/tv-hat.md
@@ -4,7 +4,7 @@ name: TV HAT
 class: board
 type: other
 formfactor: pHAT
-manufacturer: Rasbperry Pi
+manufacturer: Raspberry Pi
 description: Receives digital DVB-T2 TV streams on your Raspberry Pi to view them or stream them over a network to other devices.
 url: https://www.raspberrypi.org/products/raspberry-pi-tv-hat/
 github:

--- a/src/fr/translate/tv-hat.md
+++ b/src/fr/translate/tv-hat.md
@@ -4,7 +4,7 @@ name: TV HAT
 class: board
 type: other
 formfactor: pHAT
-manufacturer: Rasbperry Pi
+manufacturer: Raspberry Pi
 description: Receives digital DVB-T2 TV streams on your Raspberry Pi to view them or stream them over a network to other devices.
 url: https://www.raspberrypi.org/products/raspberry-pi-tv-hat/
 github:

--- a/src/it/translate/tv-hat.md
+++ b/src/it/translate/tv-hat.md
@@ -4,7 +4,7 @@ name: TV HAT
 class: board
 type: other
 formfactor: pHAT
-manufacturer: Rasbperry Pi
+manufacturer: Raspberry Pi
 description: Receives digital DVB-T2 TV streams on your Raspberry Pi to view them or stream them over a network to other devices.
 url: https://www.raspberrypi.org/products/raspberry-pi-tv-hat/
 github:

--- a/src/tr/translate/tv-hat.md
+++ b/src/tr/translate/tv-hat.md
@@ -4,7 +4,7 @@ name: TV HAT
 class: board
 type: other
 formfactor: pHAT
-manufacturer: Rasbperry Pi
+manufacturer: Raspberry Pi
 description: Receives digital DVB-T2 TV streams on your Raspberry Pi to view them or stream them over a network to other devices.
 url: https://www.raspberrypi.org/products/raspberry-pi-tv-hat/
 github:


### PR DESCRIPTION
Hi Phil, Typo in the "manufacturer" tag for the TV Hat. "Rasbperry Pi" should be "Raspberry Pi".

Not a big problem, but you do end up with an extra name in the "Manufacturer" section of the board browser.

Hope the cold gets better soon, and really loving your new office space, LEDs and all!
