### PR TITLE
UART: Label UARTs, disambiguate Pi4-only, for #428

### DIFF
--- a/generate-html.py
+++ b/generate-html.py
@@ -52,6 +52,7 @@ default_strings = {
     'uses_spi': 'Uses SPI',
     'uses_n_gpio_pins': 'Uses {} GPIO pins',
     'bcm_pin_rev1_pi': 'GPIO/BCM pin {} on Rev 1 ( very early ) Pi',
+    'supported_on': 'Supported on {} only',
     'physical_pin_n': 'Physical/Board pin {}',
     'wiring_pi_pin': 'Wiring Pi pin {}',
     'made_by': 'Made by {manufacturer}',
@@ -462,6 +463,9 @@ def render_pin(pin_num, selected_url, overlay=None):
         if 'wiringpi' in pin['scheme']:
             wiringpi = pin['scheme']['wiringpi']
             pin_link_title.append(strings['wiring_pi_pin'].format(wiringpi))
+
+    if 'supported' in overlay_pin:
+        pin_link_title.append(strings['supported_on'].format(overlay_pin['supported']))
 
     pin_url = base_url + slugify('pin{}_{}'.format(pin_num, pin_url))
 

--- a/src/de/template/localised.yaml
+++ b/src/de/template/localised.yaml
@@ -20,6 +20,7 @@ strings:
 - uses_3v3: '3v3 Stromversorgung'
 - uses_n_gpio_pins: 'benutzt {} GPIO Anschlüsse'
 - bcm_pin_rev1_pi: 'BCM Anschluss {} auf dem Rev 1 ( sehr alter ) Pi'
+- supported_on: 'Supported on {} only'
 - physical_pin_n: 'Physical pin {}'
 - wiring_pi_pin: 'Wiring Pi Anschluss {}'
 - made_by: 'Hersteller: {manufacturer}'

--- a/src/en/overlay/uart.md
+++ b/src/en/overlay/uart.md
@@ -8,77 +8,91 @@ url: http://elinux.org/RPi_Serial_Connection
 pincount: 18
 pin:
   '8':
-    name: TXD / Transmit
+    name: UART0/1 TXD
     direction: output
     active: high
   '10':
-    name: RXD / Receive
+    name: UART0/1 RXD
     direction: input
     active: high
   '36':
-    name: CTS / Clear to Send
+    name: UART0/1 CTS
     direction: both
     active: high
   '11':
-    name: RTS / Request to Send
+    name: UART0/1 RTS
     direction: both
     active: high
   '27':
-    name: TXD / Transmit
+    name: UART2 TXD
     direction: output
     active: high
+    supported: Pi4
   '28':
-    name: RXD / Receive
+    name: UART2 RXD
     direction: input
     active: high
+    supported: Pi4
   '3':
-    name: CTS / Clear to Send
+    name: UART2 CTS
     direction: both
     active: high
+    supported: Pi4
   '5':
-    name: RTS / Request to Send
+    name: UART2 RTS
     direction: both
     active: high
+    supported: Pi4
   '7':
-    name: TXD / Transmit
+    name: UART3 TXD
     direction: output
     active: high
+    supported: Pi4
   '29':
-    name: RXD / Receive
+    name: UART3 RXD
     direction: input
     active: high
+    supported: Pi4
   '31':
-    name: CTS / Clear to Send
+    name: UART3 CTS
     direction: both
     active: high
+    supported: Pi4
   '26':
-    name: RTS / Request to Send
+    name: UART3 RTS
     direction: both
     active: high
+    supported: Pi4
   '24':
-    name: TXD / Transmit
+    name: UART4 TXD
     direction: output
     active: high
+    supported: Pi4
   '21':
-    name: RXD / Receive
+    name: UART4 RXD
     direction: input
     active: high
+    supported: Pi4
   '19':
-    name: CTS / Clear to Send
+    name: UART4 CTS
     direction: both
     active: high
+    supported: Pi4
   '23':
-    name: RTS / Request to Send
+    name: UART4 RTS
     direction: both
     active: high
+    supported: Pi4
   '32':
-    name: TXD / Transmit
+    name: UART5 TXD
     direction: output
     active: high
+    supported: Pi4
   '33':
-    name: RXD / Receive
+    name: UART5 RXD
     direction: input
     active: high
+    supported: Pi4
 -->
 # UART - Universal Asynchronous Receiver/Transmitter
 ---
@@ -87,6 +101,11 @@ pin:
 ---
 UART is an asynchronous serial communication protocol, meaning that it takes bytes of data and transmits the individual bits in a sequential fashion.
 
+* TXD - Transmit
+* RXD - Receive
+* CTS - Clear to send
+* RTS - Request to send
+
 Asynchronous transmission allows data to be transmitted without the sender having to send a clock signal to the receiver. Instead, the sender and receiver agree on timing parameters in advance and special bits called 'start bits' are added to each word and used to synchronize the sending and receiving units.
 
 UART is commonly used on the Pi as a convenient way to control it over the GPIO, or access the kernel boot messages from the serial console (enabled by default).
@@ -94,12 +113,3 @@ UART is commonly used on the Pi as a convenient way to control it over the GPIO,
 It can also be used as a way to interface an Arduino, bootloaded ATmega, ESP8266, etc with your Pi. Be careful with logic-levels between the devices though, for example the Pi is 3.3v and the Arduino is 5v. Connect the two and you might conjure up some magic blue smoke.
 
 Raspberry Pi 2/3 have two UARTs, uart1 and uart0. Raspberry Pi 4 has four additional UARTs available. Only uart0/1 is enabled over GPIO pin 14/15 by default. The additional UARTs can be enabled through the device tree overlays.
-
-Assuming you have WiringPi-Python installed, the following python example opens the Pi's UART at 9600baud and puts 'hello world'
-
-```python
-import wiringpi
-wiringpi.wiringPiSetup()
-serial = wiringpi.serialOpen('/dev/ttyAMA0',9600)
-wiringpi.serialPuts(serial,'hello world!')
-```

--- a/src/en/template/localised.yaml
+++ b/src/en/template/localised.yaml
@@ -20,6 +20,7 @@ strings:
 - uses_3v3: 'Needs 3v3 power'
 - uses_n_gpio_pins: 'Uses {} GPIO pins'
 - bcm_pin_rev1_pi: 'GPIO/BCM pin {} on Rev 1 ( very early ) Pi'
+- supported_on: 'Supported on {} only'
 - physical_pin_n: 'Physical/Board pin {}'
 - wiring_pi_pin: 'Wiring Pi pin {}'
 - made_by: 'Made by {manufacturer}'

--- a/src/es/template/localised.yaml
+++ b/src/es/template/localised.yaml
@@ -20,6 +20,7 @@ strings:
 - uses_3v3: 'Alimentación 3v3'
 - uses_n_gpio_pins: 'Usa {} pines GPIO'
 - bcm_pin_rev1_pi: 'pin BCP {} en Rev 1 (primera) Pi'
+- supported_on: 'Supported on {} only'
 - physical_pin_n: 'pin físico {}'
 - wiring_pi_pin: 'pin Wiring Pi {}'
 - made_by: 'Fabricado por {manufacturer}'

--- a/src/fr/template/localised.yaml
+++ b/src/fr/template/localised.yaml
@@ -20,6 +20,7 @@ strings:
 - uses_3v3: 'alimentation 3v3'
 - uses_n_gpio_pins: '{} broches GPIO actives'
 - bcm_pin_rev1_pi: 'broche BCM {} sur Raspi Rev 1'
+- supported_on: 'Supported on {} only'
 - physical_pin_n: 'broche physique {}'
 - wiring_pi_pin: 'broche Wiring Pi {}'
 - made_by: 'fabriqué par {manufacturer}'

--- a/src/it/template/localised.yaml
+++ b/src/it/template/localised.yaml
@@ -20,6 +20,7 @@ strings:
 - uses_3v3: 'Alimentazione a 3.3V'
 - uses_n_gpio_pins: 'Utilizza {} GPIO pins'
 - bcm_pin_rev1_pi: 'BCM pin {} su Raspberry Rev 1 (le prime edizioni)'
+- supported_on: 'Supported on {} only'
 - physical_pin_n: 'Pin fisico {}'
 - wiring_pi_pin: 'Wiring Pi pin {}'
 - made_by: 'Prodotto da {manufacturer}'

--- a/src/tr/template/localised.yaml
+++ b/src/tr/template/localised.yaml
@@ -20,6 +20,7 @@ strings:
 - uses_3v3: '3.3V Güç'
 - uses_n_gpio_pins: 'Kullanan {} GPIO pins'
 - bcm_pin_rev1_pi: 'BCM pin {} on Rev 1 ( very early ) Pi'
+- supported_on: 'Supported on {} only'
 - physical_pin_n: 'Physical pin {}'
 - wiring_pi_pin: 'Wiring Pi pin {}'
 - made_by: 'Yapılan {manufacturer}'


### PR DESCRIPTION
Add an new "supported:" property to overlay pins in order to declare which Pi versions this feature is supported on.