### PR TITLE
Apply #441 (Voice Hat: "I2C"->"I2S" and add Pin 38) changes across all languages

### DIFF
--- a/src/en/overlay/voice-hat.md
+++ b/src/en/overlay/voice-hat.md
@@ -59,8 +59,10 @@ pin:
     name: Amp Shutdown
   '37':
     name: Servo 0 Breakout
+  '38':
+    name: I2S Data Input
   '40':
-    name: I2S Data
+    name: I2S Data Output
 install:
   'devices':
   - 'i2s'

--- a/src/es/translate/voice-hat.md
+++ b/src/es/translate/voice-hat.md
@@ -59,8 +59,10 @@ pin:
     name: Amp Shutdown
   '37':
     name: Servo 0 Breakout
+  '38':
+    name: I2S Data Input
   '40':
-    name: I2S Data
+    name: I2S Data Output
 install:
   'devices':
   - 'i2s'

--- a/src/fr/translate/voice-hat.md
+++ b/src/fr/translate/voice-hat.md
@@ -59,8 +59,10 @@ pin:
     name: Amp Shutdown
   '37':
     name: Servo 0 Breakout
+  '38':
+    name: I2S Data Input
   '40':
-    name: I2S Data
+    name: I2S Data Output
 install:
   'devices':
   - 'i2s'

--- a/src/it/translate/voice-hat.md
+++ b/src/it/translate/voice-hat.md
@@ -59,8 +59,10 @@ pin:
     name: Amp Shutdown
   '37':
     name: Servo 0 Breakout
+  '38':
+    name: I2S Data Input
   '40':
-    name: I2S Data
+    name: I2S Data Output
 install:
   'devices':
   - 'i2s'

--- a/src/tr/translate/voice-hat.md
+++ b/src/tr/translate/voice-hat.md
@@ -59,8 +59,10 @@ pin:
     name: Amp Shutdown
   '37':
     name: Servo 0 Breakout
+  '38':
+    name: I2S Data Input
   '40':
-    name: I2S Data
+    name: I2S Data Output
 install:
   'devices':
   - 'i2s'


### PR DESCRIPTION
Fixes my previous mistake of updating `voice-hat.md` in one random localization instead of all six in #441.

(I don't see a `pin-38.md` in any localizations except `en`)