### PR TITLE
The AIY Voice Bonnet does not use UART pins

### DIFF
--- a/src/de/translate/aiy-voice-bonnet.md
+++ b/src/de/translate/aiy-voice-bonnet.md
@@ -28,12 +28,6 @@ pin:
     mode: i2c
   '5':
     mode: i2c
-  '8':
-    mode: uart
-    name: TXD breakout
-  '10':
-    mode: uart
-    name: RXD breakout
   '12':
     mode: i2s
     name: I2S BCLK

--- a/src/en/overlay/aiy-voice-bonnet.md
+++ b/src/en/overlay/aiy-voice-bonnet.md
@@ -28,12 +28,6 @@ pin:
     mode: i2c
   '5':
     mode: i2c
-  '8':
-    mode: uart
-    name: TXD breakout
-  '10':
-    mode: uart
-    name: RXD breakout
   '12':
     mode: i2s
     name: I2S BCLK

--- a/src/es/overlay/aiy-voice-bonnet.md
+++ b/src/es/overlay/aiy-voice-bonnet.md
@@ -28,12 +28,6 @@ pin:
     mode: i2c
   '5':
     mode: i2c
-  '8':
-    mode: uart
-    name: TXD breakout
-  '10':
-    mode: uart
-    name: RXD breakout
   '12':
     mode: i2s
     name: I2S BCLK

--- a/src/fr/translate/aiy-voice-bonnet.md
+++ b/src/fr/translate/aiy-voice-bonnet.md
@@ -28,12 +28,6 @@ pin:
     mode: i2c
   '5':
     mode: i2c
-  '8':
-    mode: uart
-    name: TXD breakout
-  '10':
-    mode: uart
-    name: RXD breakout
   '12':
     mode: i2s
     name: I2S BCLK

--- a/src/it/translate/aiy-voice-bonnet.md
+++ b/src/it/translate/aiy-voice-bonnet.md
@@ -28,12 +28,6 @@ pin:
     mode: i2c
   '5':
     mode: i2c
-  '8':
-    mode: uart
-    name: TXD breakout
-  '10':
-    mode: uart
-    name: RXD breakout
   '12':
     mode: i2s
     name: I2S BCLK

--- a/src/tr/translate/aiy-voice-bonnet.md
+++ b/src/tr/translate/aiy-voice-bonnet.md
@@ -28,12 +28,6 @@ pin:
     mode: i2c
   '5':
     mode: i2c
-  '8':
-    mode: uart
-    name: TXD breakout
-  '10':
-    mode: uart
-    name: RXD breakout
   '12':
     mode: i2s
     name: I2S BCLK


### PR DESCRIPTION
product documentation at https://aiyprojects.withgoogle.com/voice#makers-guide--gpio-header-pinout confirms; verified with my own project using the same pins. 

Thanks!!